### PR TITLE
Updating typescript version to support new version of bignumber.js (9.1.0)

### DIFF
--- a/CURRENT/typescript/org/mariuszgromada/math/mxparser/mathcollection/MathFunctions.ts
+++ b/CURRENT/typescript/org/mariuszgromada/math/mxparser/mathcollection/MathFunctions.ts
@@ -6,7 +6,7 @@ import { Units } from './Units';
 import { SpecialFunctions } from './SpecialFunctions';
 import { MathConstants } from './MathConstants';
 import { BinaryRelations } from './BinaryRelations';
-import { BigNumber } from 'bignumber.js/bignumber';
+import { BigNumber } from 'bignumber.js/bignumber.js';
 
 /**
  * MathFunctions - the most popular math functions. Many of function implemented by this class

--- a/CURRENT/typescript/org/mariuszgromada/math/mxparser/mathcollection/NumberTheory.ts
+++ b/CURRENT/typescript/org/mariuszgromada/math/mxparser/mathcollection/NumberTheory.ts
@@ -10,7 +10,7 @@ import { BooleanAlgebra } from './BooleanAlgebra';
 import { BinaryRelations } from './BinaryRelations';
 import { javaemul } from 'j4ts/j4ts';
 import { java } from 'j4ts/j4ts';
-import { BigNumber } from 'bignumber.js/bignumber';
+import { BigNumber } from 'bignumber.js/bignumber.js';
 
 /**
  * NumberTheory - summation / products etc...

--- a/CURRENT/typescript/package-lock.json
+++ b/CURRENT/typescript/package-lock.json
@@ -1,21 +1,13 @@
 {
-  "name": "mxparserts",
-  "version": "1.0.0",
+  "name": "mathparser.org-mxparser",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/bignumber.js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
-      "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
-      "requires": {
-        "bignumber.js": "*"
-      }
-    },
     "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
     },
     "j4ts": {
       "version": "0.7.2",

--- a/CURRENT/typescript/package.json
+++ b/CURRENT/typescript/package.json
@@ -9,13 +9,19 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Thilo Schaber",
-  "keywords": ["mxparser", "math-parser", "formula-parser"],
-  "repository": { "type": "git", "url": "git+https://github.com/mariuszgromada/MathParser.org-mXparser.git"},
+  "keywords": [
+    "mxparser",
+    "math-parser",
+    "formula-parser"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mariuszgromada/MathParser.org-mXparser.git"
+  },
   "homepage": "http://mathparser.org/",
   "license": "ISC",
   "dependencies": {
-    "@types/bignumber.js": "^5.0.0",
-    "bignumber.js": "^9.0.1",
+    "bignumber.js": "^9.1.0",
     "j4ts": "^0.7.2",
     "tsc": "^1.20150623.0",
     "typescript": "^4.2.4"


### PR DESCRIPTION
Dependency bignumber.js updated some days ago with a new minor version which breaks all the previous import statements.

It is no longer possible to use MathParser in a typescript project (without explicitly depending on bignumber.js@9.0.2) since it doesn't compile anymore because package.json states that it supports bignumber.js 9.0.1 **and above**, so dependent projects download version 9.1.0 and it breaks everything.

With this pull request MathParser upgrades to the new version of bignumber.js so it is usable again.

Thanks!