### PR TITLE
use correct framework

### DIFF
--- a/CURRENT/c-sharp/mXparser.nuspec
+++ b/CURRENT/c-sharp/mXparser.nuspec
@@ -40,11 +40,11 @@
     <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\netcoreapp3.1\*.dll" target="lib\netcoreapp3.1" />
     <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\netcoreapp3.1\*.json" target="lib\netcoreapp3.1" />	
 	
-    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net60\*.dll" target="lib\net6.0" />
-    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net60\*.json" target="lib\net6.0" />
+    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net6.0\*.dll" target="lib\net6.0" />
+    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net6.0\*.json" target="lib\net6.0" />
 
-    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net80\*.dll" target="lib\net8.0" />
-    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net80\*.json" target="lib\net8.0" />
+    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net8.0\*.dll" target="lib\net8.0" />
+    <file src="tests-and-release\2-Release-NetF-Stand-Core-Net\bin\Release\net8.0\*.json" target="lib\net8.0" />
 
 	
 	<file src="..\..\LICENSE.txt" target="" />

--- a/CURRENT/c-sharp/tests-and-release/2-Release-NetF-Stand-Core-Net/2-Release-NetF-Stand-Core-Net.csproj
+++ b/CURRENT/c-sharp/tests-and-release/2-Release-NetF-Stand-Core-Net/2-Release-NetF-Stand-Core-Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net462;net472;net481;netstandard2.1;netcoreapp3.1;net60;net80</TargetFrameworks>
+    <TargetFrameworks>net35;net462;net472;net481;netstandard2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>MathParser.org-mXparser</AssemblyName>
     <RootNamespace>mxparser</RootNamespace>
     <PackageId>MathParser.org-mXparser</PackageId>

--- a/CURRENT/c-sharp/tests-and-release/6-Unit-Tests-Net6/6-Unit-Tests-Net6.csproj
+++ b/CURRENT/c-sharp/tests-and-release/6-Unit-Tests-Net6/6-Unit-Tests-Net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>UnitTestsNet6</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/CURRENT/c-sharp/tests-and-release/7-Unit-Tests-Net8/7-Unit-Tests-Net8.csproj
+++ b/CURRENT/c-sharp/tests-and-release/7-Unit-Tests-Net8/7-Unit-Tests-Net8.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>UnitTestsNet7</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/CURRENT/c-sharp/tests-and-release/8-Lib-Test/8-Lib-Test.csproj
+++ b/CURRENT/c-sharp/tests-and-release/8-Lib-Test/8-Lib-Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net481;netstandard2.1;netcoreapp3.1;net60;net80</TargetFrameworks>
+    <TargetFrameworks>net481;netstandard2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>MathParser.org-mXparser</AssemblyName>
     <RootNamespace>mxparser</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks